### PR TITLE
Add Vagrantfile; use racker/precise-with-updates

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,29 @@
+Vagrant.configure("2") do |config|
+  dev_dir = ENV["VAGRANT_DEV_DIR"] || "#{ENV['HOME']}/dev"
+  
+  config.vm.define :docker do |docker|
+    # precise64 base box, with saucy kernel installed, updated virtualbox guest additions, and apt updates
+    # If you want to use something other than virtualbox, just install linux-{image,headers}-generic-lts-saucy
+    # reboot, then install $vm utilities
+    docker.vm.box = 'docker'
+  end
+
+  config.vm.network "private_network", ip: "192.168.0.4"
+  config.vm.synced_folder dev_dir, "/data/dev", type: "nfs"
+
+  config.vm.provider "virtualbox" do |v,o|
+    o.vm.box_url = 'http://ad0aa5dd3337e66b1480-a8edc52000ffb652c3d7c76d3a4040f6.r98.cf2.rackcdn.com/teeth2.box'
+    v.customize ["modifyvm", :id, "--memory", 2048]
+    # added because https://github.com/dotcloud/docker/pull/1813
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+  end
+
+  config.vm.provider "vmware_fusion" do |v,o|
+    o.vm.box_url = 'http://ad0aa5dd3337e66b1480-a8edc52000ffb652c3d7c76d3a4040f6.r98.cf2.rackcdn.com/teeth2-vmware.box'
+    v.customize ["modifyvm", :id, "--memory", 2048]
+  end
+
+  config.vm.provision "docker"
+
+end

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -4,7 +4,7 @@
 # Date: 08/11/2013
 
 
-FROM stackbrew/ubuntu:precise
+FROM racker/precise-with-updates
 MAINTAINER Paul Czarkowski "paul@paulcz.net"
 
 RUN apt-get -yqq update

--- a/glance/Dockerfile
+++ b/glance/Dockerfile
@@ -4,7 +4,7 @@
 # Date: 08/11/2013
 
 
-FROM openstack/common
+FROM racker/precise-with-updates
 MAINTAINER Paul Czarkowski "paul@paulcz.net"
 
 RUN git clone --depth 1 -b stable/havana https://github.com/openstack/glance.git /opt/openstack/glance

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -4,7 +4,7 @@
 # Date: 08/04/2013
 
 
-FROM openstack/common
+FROM racker/precise-with-updates
 MAINTAINER Paul Czarkowski "paul@paulcz.net"
 
 RUN apt-get -yqq install rabbitmq-server


### PR DESCRIPTION
Useful for developing against this on non-linux OSes.

Set VAGRANT_DEV_DIR to be a development directory to NFS mount into the vagrant image; defaults to ~/dev.

Additionally, use racker/precise-with-updates (Issue #2) so that we get security updates daily for free.
